### PR TITLE
Provide `RenderableSpec` using `RenderSpecProvider`

### DIFF
--- a/src/main/kotlin/org/simple/bppassportgen/App.kt
+++ b/src/main/kotlin/org/simple/bppassportgen/App.kt
@@ -6,6 +6,7 @@ import org.apache.commons.cli.Options
 import org.apache.pdfbox.cos.COSName
 import org.apache.pdfbox.pdmodel.graphics.color.PDColor
 import org.apache.pdfbox.pdmodel.graphics.color.PDDeviceCMYK
+import org.simple.bppassportgen.generator.GeneratorType
 import org.simple.bppassportgen.renderable.Renderable.Type.PassportQrCode
 import org.simple.bppassportgen.renderable.Renderable.Type.PassportShortcode
 import org.simple.bppassportgen.renderable.qrcode.BarcodeRenderSpec
@@ -79,7 +80,8 @@ fun main(args: Array<String>) {
           rowCount = rowCount,
           columnCount = columnCount,
           templateFilePath = templateFilePath,
-          outputDirectory = outDirectory
+          outputDirectory = outDirectory,
+          generatorType = if (isSticker) GeneratorType.Sticker else GeneratorType.Passport
       )
     }
   }

--- a/src/main/kotlin/org/simple/bppassportgen/App.kt
+++ b/src/main/kotlin/org/simple/bppassportgen/App.kt
@@ -53,18 +53,6 @@ fun main(args: Array<String>) {
       val blackCmykId = "cmyk_black"
 
       val uuidsToGenerate = (0 until numberOfPassports).map { UUID.randomUUID() }
-      val renderSpecs = listOf(
-          RenderableSpec(0, PassportQrCode, if (isSticker) {
-            BarcodeRenderSpec(width = 80, height = 80, matrixScale = 0.85F, positionX = 4.5F, positionY = 17F, colorId = blackCmykId)
-          } else {
-            BarcodeRenderSpec(width = 80, height = 80, matrixScale = 1.35F, positionX = 196F, positionY = 107.5F, colorId = blackCmykId)
-          }),
-          RenderableSpec(0, PassportShortcode, if (isSticker) {
-            ShortcodeRenderSpec(positionX = 16F, positionY = 8F, fontSize = 8F, characterSpacing = 1.2F, fontId = metropolisFontId, colorId = blackCmykId)
-          } else {
-            ShortcodeRenderSpec(positionX = 88F, positionY = 210F, fontSize = 12F, characterSpacing = 2.4F, fontId = metropolisFontId, colorId = blackCmykId)
-          })
-      )
       val fonts = mapOf(metropolisFontId to "Metropolis-Medium.ttf")
       val colors = mapOf(blackCmykId to PDColor(
           floatArrayOf(0F, 0F, 0F, 1F),
@@ -74,7 +62,6 @@ fun main(args: Array<String>) {
 
       PassportsGenerator(
           fonts = fonts,
-          renderSpecs = renderSpecs,
           renderSpecProvider = RenderSpecProviderImpl(),
           colorMap = colors
       ).run(

--- a/src/main/kotlin/org/simple/bppassportgen/App.kt
+++ b/src/main/kotlin/org/simple/bppassportgen/App.kt
@@ -7,6 +7,7 @@ import org.apache.pdfbox.cos.COSName
 import org.apache.pdfbox.pdmodel.graphics.color.PDColor
 import org.apache.pdfbox.pdmodel.graphics.color.PDDeviceCMYK
 import org.simple.bppassportgen.generator.GeneratorType
+import org.simple.bppassportgen.renderable.RenderSpecProviderImpl
 import org.simple.bppassportgen.renderable.Renderable.Type.PassportQrCode
 import org.simple.bppassportgen.renderable.Renderable.Type.PassportShortcode
 import org.simple.bppassportgen.renderable.qrcode.BarcodeRenderSpec
@@ -74,6 +75,7 @@ fun main(args: Array<String>) {
       PassportsGenerator(
           fonts = fonts,
           renderSpecs = renderSpecs,
+          renderSpecProvider = RenderSpecProviderImpl(),
           colorMap = colors
       ).run(
           uuidsToGenerate = uuidsToGenerate,

--- a/src/main/kotlin/org/simple/bppassportgen/PassportsGenerator.kt
+++ b/src/main/kotlin/org/simple/bppassportgen/PassportsGenerator.kt
@@ -10,6 +10,7 @@ import org.simple.bppassportgen.progresspoll.ProgressPoll
 import org.simple.bppassportgen.progresspoll.RealProgressPoll
 import org.simple.bppassportgen.qrcodegen.QrCodeGenerator
 import org.simple.bppassportgen.qrcodegen.QrCodeGeneratorImpl
+import org.simple.bppassportgen.renderable.RenderSpecProvider
 import org.simple.bppassportgen.renderable.Renderable
 import org.simple.bppassportgen.renderable.Renderable.Type.PassportQrCode
 import org.simple.bppassportgen.renderable.Renderable.Type.PassportShortcode
@@ -30,6 +31,7 @@ class PassportsGenerator(
     private val consolePrinter: ConsolePrinter = RealConsolePrinter(),
     private val fonts: Map<String, String>,
     private val renderSpecs: List<RenderableSpec>,
+    private val renderSpecProvider: RenderSpecProvider,
     private val colorMap: Map<String, PDColor>,
     private val pageCount: Int = 100
 ) {

--- a/src/main/kotlin/org/simple/bppassportgen/PassportsGenerator.kt
+++ b/src/main/kotlin/org/simple/bppassportgen/PassportsGenerator.kt
@@ -71,7 +71,7 @@ class PassportsGenerator(
           val pageSpecs = uuidBatch
               .map { uuidsInEachPage ->
                 uuidsInEachPage.map { uuid ->
-                  PageSpec(generateRenderables(qrCodeGenerator, uuid, colorProvider))
+                  PageSpec(generateRenderables(qrCodeGenerator, uuid, colorProvider, renderSpecProvider.renderSpecs(generatorType)))
                 }
               }
               .toList()
@@ -128,7 +128,8 @@ class PassportsGenerator(
   private fun generateRenderables(
       qrCodeGenerator: QrCodeGenerator,
       uuid: UUID,
-      colorProvider: ColorProvider
+      colorProvider: ColorProvider,
+      renderSpecs: List<RenderableSpec>
   ): Map<Int, List<Renderable>> {
     return renderSpecs
         .map { it.pageNumber to generateRenderable(uuid, qrCodeGenerator, it, colorProvider) }

--- a/src/main/kotlin/org/simple/bppassportgen/PassportsGenerator.kt
+++ b/src/main/kotlin/org/simple/bppassportgen/PassportsGenerator.kt
@@ -1,7 +1,6 @@
 package org.simple.bppassportgen
 
 import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
-import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.pdmodel.graphics.color.PDColor
 import org.simple.bppassportgen.consoleprinter.ConsolePrinter
 import org.simple.bppassportgen.consoleprinter.RealConsolePrinter
@@ -30,7 +29,6 @@ class PassportsGenerator(
     private val progressPoll: ProgressPoll = RealProgressPoll(Duration.ofSeconds(1)),
     private val consolePrinter: ConsolePrinter = RealConsolePrinter(),
     private val fonts: Map<String, String>,
-    private val renderSpecs: List<RenderableSpec>,
     private val renderSpecProvider: RenderSpecProvider,
     private val colorMap: Map<String, PDColor>,
     private val pageCount: Int = 100

--- a/src/main/kotlin/org/simple/bppassportgen/PassportsGenerator.kt
+++ b/src/main/kotlin/org/simple/bppassportgen/PassportsGenerator.kt
@@ -5,6 +5,7 @@ import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.pdmodel.graphics.color.PDColor
 import org.simple.bppassportgen.consoleprinter.ConsolePrinter
 import org.simple.bppassportgen.consoleprinter.RealConsolePrinter
+import org.simple.bppassportgen.generator.GeneratorType
 import org.simple.bppassportgen.progresspoll.ProgressPoll
 import org.simple.bppassportgen.progresspoll.RealProgressPoll
 import org.simple.bppassportgen.qrcodegen.QrCodeGenerator
@@ -38,7 +39,8 @@ class PassportsGenerator(
       rowCount: Int,
       columnCount: Int,
       templateFilePath: String,
-      outputDirectory: File
+      outputDirectory: File,
+      generatorType: GeneratorType
   ) {
     val mergeCount = rowCount * columnCount
 

--- a/src/main/kotlin/org/simple/bppassportgen/generator/PassportsGeneratorEffect.kt
+++ b/src/main/kotlin/org/simple/bppassportgen/generator/PassportsGeneratorEffect.kt
@@ -7,5 +7,6 @@ data class GenerateBpPassports(
     val outputDirectoryPath: String,
     val numberOfPassports: Int,
     val rowCount: Int,
-    val columnCount: Int
+    val columnCount: Int,
+    val generatorType: GeneratorType
 ) : PassportsGeneratorEffect()

--- a/src/main/kotlin/org/simple/bppassportgen/generator/PassportsGeneratorEffectHandler.kt
+++ b/src/main/kotlin/org/simple/bppassportgen/generator/PassportsGeneratorEffectHandler.kt
@@ -30,7 +30,9 @@ class PassportsGeneratorEffectHandler(
                 rowCount = effect.rowCount,
                 columnCount = effect.columnCount,
                 templateFilePath = effect.templateFilePath,
-                outputDirectory = File(effect.outputDirectoryPath))
+                outputDirectory = File(effect.outputDirectoryPath),
+                generatorType = effect.generatorType
+            )
           }
           .map { PassportsGenerated }
     }

--- a/src/main/kotlin/org/simple/bppassportgen/generator/PassportsGeneratorUpdate.kt
+++ b/src/main/kotlin/org/simple/bppassportgen/generator/PassportsGeneratorUpdate.kt
@@ -24,7 +24,8 @@ class PassportsGeneratorUpdate : Update<PassportsGeneratorModel, PassportsGenera
           outputDirectoryPath = model.outputDirectoryPath!!,
           numberOfPassports = model.numberOfPassports!!,
           rowCount = model.pageSize.rows,
-          columnCount = model.pageSize.columns
+          columnCount = model.pageSize.columns,
+          generatorType = model.generatorType
         )))
       }
       is PageSizeChanged -> next(model.pageSizeChanged(event.pageSize))

--- a/src/main/kotlin/org/simple/bppassportgen/renderable/RenderSpecProvider.kt
+++ b/src/main/kotlin/org/simple/bppassportgen/renderable/RenderSpecProvider.kt
@@ -1,0 +1,61 @@
+package org.simple.bppassportgen.renderable
+
+import org.simple.bppassportgen.RenderableSpec
+import org.simple.bppassportgen.generator.GeneratorType
+import org.simple.bppassportgen.renderable.qrcode.BarcodeRenderSpec
+import org.simple.bppassportgen.renderable.shortcode.ShortcodeRenderSpec
+
+interface RenderSpecProvider {
+  fun renderSpecs(generatorType: GeneratorType): List<RenderableSpec>
+}
+
+class RenderSpecProviderImpl : RenderSpecProvider {
+
+  private val metropolisFontId = "Metropolis-Medium"
+  private val blackCmykId = "cmyk_black"
+
+  override fun renderSpecs(generatorType: GeneratorType): List<RenderableSpec> {
+    val barcodeRenderSpec = when (generatorType) {
+      GeneratorType.Passport -> BarcodeRenderSpec(
+        width = 80,
+        height = 80,
+        matrixScale = 1.35F,
+        positionX = 196F,
+        positionY = 107.5F,
+        colorId = blackCmykId
+      )
+      GeneratorType.Sticker -> BarcodeRenderSpec(
+        width = 80,
+        height = 80,
+        matrixScale = 0.85F,
+        positionX = 4.5F,
+        positionY = 17F,
+        colorId = blackCmykId
+      )
+    }
+
+    val shortcodeRenderSpec = when (generatorType) {
+      GeneratorType.Passport -> ShortcodeRenderSpec(
+        positionX = 88F,
+        positionY = 210F,
+        fontSize = 12F,
+        characterSpacing = 2.4F,
+        fontId = metropolisFontId,
+        colorId = blackCmykId
+      )
+      GeneratorType.Sticker -> ShortcodeRenderSpec(
+        positionX = 16F,
+        positionY = 8F,
+        fontSize = 8F,
+        characterSpacing = 1.2F,
+        fontId = metropolisFontId,
+        colorId = blackCmykId
+      )
+    }
+
+    return listOf(
+      RenderableSpec(0, Renderable.Type.PassportQrCode, barcodeRenderSpec),
+      RenderableSpec(0, Renderable.Type.PassportShortcode, shortcodeRenderSpec)
+    )
+  }
+}

--- a/src/test/kotlin/org/simple/clinic/bppassportgen/approvals/VerifyTestBase.kt
+++ b/src/test/kotlin/org/simple/clinic/bppassportgen/approvals/VerifyTestBase.kt
@@ -9,6 +9,7 @@ import org.junit.Before
 import org.simple.bppassportgen.PassportsGenerator
 import org.simple.bppassportgen.RenderableSpec
 import org.simple.clinic.bppassportgen.SavePdfToImage
+import org.simple.clinic.bppassportgen.renderable.TestRenderSpecProvider
 import org.simple.clinic.bppassportgen.util.ImageApprover
 import org.simple.clinic.bppassportgen.util.NoOpConsolePrinter
 import org.simple.clinic.bppassportgen.util.NoOpProgressPoll
@@ -34,6 +35,7 @@ abstract class VerifyTestBase(
         consolePrinter = NoOpConsolePrinter(),
         fonts = fonts,
         renderSpecs = renderSpecs,
+        renderSpecProvider = TestRenderSpecProvider(),
         colorMap = colors
     )
   }

--- a/src/test/kotlin/org/simple/clinic/bppassportgen/approvals/VerifyTestBase.kt
+++ b/src/test/kotlin/org/simple/clinic/bppassportgen/approvals/VerifyTestBase.kt
@@ -34,7 +34,6 @@ abstract class VerifyTestBase(
         progressPoll = NoOpProgressPoll(),
         consolePrinter = NoOpConsolePrinter(),
         fonts = fonts,
-        renderSpecs = renderSpecs,
         renderSpecProvider = TestRenderSpecProvider(),
         colorMap = colors
     )

--- a/src/test/kotlin/org/simple/clinic/bppassportgen/approvals/verifypdfs/VerifyGenerationOfPdf.kt
+++ b/src/test/kotlin/org/simple/clinic/bppassportgen/approvals/verifypdfs/VerifyGenerationOfPdf.kt
@@ -5,6 +5,7 @@ import org.apache.pdfbox.pdmodel.graphics.color.PDColor
 import org.apache.pdfbox.pdmodel.graphics.color.PDDeviceCMYK
 import org.junit.Test
 import org.simple.bppassportgen.RenderableSpec
+import org.simple.bppassportgen.generator.GeneratorType
 import org.simple.bppassportgen.renderable.Renderable.Type
 import org.simple.bppassportgen.renderable.qrcode.BarcodeRenderSpec
 import org.simple.bppassportgen.renderable.shortcode.ShortcodeRenderSpec
@@ -69,7 +70,8 @@ class VerifyGenerationOfPdf : VerifyTestBase(
         rowCount = 2,
         columnCount = 2,
         templateFilePath = resourceFilePath("blank.pdf"),
-        outputDirectory = outputDirectory
+        outputDirectory = outputDirectory,
+        generatorType = GeneratorType.Passport
     )
 
     runApprovals(8) { pdfNumber, pageNumber: Int -> "bp pdf $pdfNumber.$pageNumber" }

--- a/src/test/kotlin/org/simple/clinic/bppassportgen/generator/PassportsGeneratorEffectHandlerTest.kt
+++ b/src/test/kotlin/org/simple/clinic/bppassportgen/generator/PassportsGeneratorEffectHandlerTest.kt
@@ -49,7 +49,8 @@ class PassportsGeneratorEffectHandlerTest {
         rowCount = 2,
         columnCount = 2,
         templateFilePath = "/template-file.pdf",
-        outputDirectory = File("/passports")
+        outputDirectory = File("/passports"),
+        generatorType = GeneratorType.Passport
     )
 
     effectHandlerTestCase.assertOutgoingEvents(PassportsGenerated)

--- a/src/test/kotlin/org/simple/clinic/bppassportgen/generator/PassportsGeneratorEffectHandlerTest.kt
+++ b/src/test/kotlin/org/simple/clinic/bppassportgen/generator/PassportsGeneratorEffectHandlerTest.kt
@@ -6,6 +6,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.simple.bppassportgen.PassportsGenerator
 import org.simple.bppassportgen.generator.GenerateBpPassports
+import org.simple.bppassportgen.generator.GeneratorType
 import org.simple.bppassportgen.generator.PassportsGenerated
 import org.simple.bppassportgen.generator.PassportsGeneratorEffectHandler
 import org.simple.clinic.bppassportgen.scheduler.TestSchedulersProvider
@@ -38,7 +39,8 @@ class PassportsGeneratorEffectHandlerTest {
         outputDirectoryPath = "/passports",
         numberOfPassports = 1,
         rowCount = 2,
-        columnCount = 2
+        columnCount = 2,
+        generatorType = GeneratorType.Passport
     ))
 
     // then

--- a/src/test/kotlin/org/simple/clinic/bppassportgen/generator/PassportsGeneratorUpdateTest.kt
+++ b/src/test/kotlin/org/simple/clinic/bppassportgen/generator/PassportsGeneratorUpdateTest.kt
@@ -112,7 +112,8 @@ class PassportsGeneratorUpdateTest {
                 outputDirectoryPath = "/output",
                 numberOfPassports = 10,
                 rowCount = 1,
-                columnCount = 2
+                columnCount = 2,
+                generatorType = GeneratorType.Passport
             ))
         ))
   }

--- a/src/test/kotlin/org/simple/clinic/bppassportgen/renderable/TestRenderSpecProvider.kt
+++ b/src/test/kotlin/org/simple/clinic/bppassportgen/renderable/TestRenderSpecProvider.kt
@@ -1,0 +1,46 @@
+package org.simple.clinic.bppassportgen.renderable
+
+import org.simple.bppassportgen.RenderableSpec
+import org.simple.bppassportgen.generator.GeneratorType
+import org.simple.bppassportgen.renderable.RenderSpecProvider
+import org.simple.bppassportgen.renderable.Renderable
+import org.simple.bppassportgen.renderable.qrcode.BarcodeRenderSpec
+import org.simple.bppassportgen.renderable.shortcode.ShortcodeRenderSpec
+
+class TestRenderSpecProvider : RenderSpecProvider {
+
+  companion object {
+    private const val FONT_ID = "Pacifico"
+    private const val RED_CMYK = "red_cmyk"
+    private const val BLUE_CMYK = "blue_cmyk"
+  }
+
+  override fun renderSpecs(generatorType: GeneratorType): List<RenderableSpec> {
+    return listOf(
+      RenderableSpec(
+        pageNumber = 0,
+        type = Renderable.Type.PassportShortcode,
+        spec = ShortcodeRenderSpec(
+          positionX = 80F,
+          positionY = 115F,
+          fontSize = 25F,
+          characterSpacing = 1.3F,
+          fontId = FONT_ID,
+          colorId = RED_CMYK
+        )
+      ),
+      RenderableSpec(
+        pageNumber = 1,
+        type = Renderable.Type.PassportQrCode,
+        spec = BarcodeRenderSpec(
+          width = 120,
+          height = 120,
+          matrixScale = 2F,
+          positionX = 10F,
+          positionY = 10F,
+          colorId = BLUE_CMYK
+        )
+      )
+    )
+  }
+}


### PR DESCRIPTION
This will allows us to properly abstract it away so that we can provide a fake in tests that we can use.